### PR TITLE
Add KeyValueStore::execute.

### DIFF
--- a/kvx/src/lib.rs
+++ b/kvx/src/lib.rs
@@ -103,6 +103,21 @@ impl KeyValueStore {
 
         Ok(KeyValueStore { inner })
     }
+
+    pub fn execute<F, T>(
+        &self,
+        scope: &Scope,
+        mut op: F
+    ) -> Result<T>
+    where F: FnMut(&dyn KeyValueStoreBackend) -> Result<T, Error>  {
+        let mut res = None;
+        self.transaction(scope, &mut |store| {
+            res = Some(op(store)?);
+            Ok(())
+        })?;
+        Ok(res.unwrap())
+    }
+
 }
 
 impl Display for KeyValueStore {

--- a/kvx/src/lib.rs
+++ b/kvx/src/lib.rs
@@ -105,7 +105,9 @@ impl KeyValueStore {
     }
 
     pub fn execute<F, T>(&self, scope: &Scope, mut op: F) -> Result<T>
-    where F: FnMut(&dyn KeyValueStoreBackend) -> Result<T, Error>  {
+    where
+        F: FnMut(&dyn KeyValueStoreBackend) -> Result<T, Error>,
+    {
         let mut res = None;
         self.transaction(scope, &mut |store| {
             res = Some(op(store)?);
@@ -113,7 +115,6 @@ impl KeyValueStore {
         })?;
         Ok(res.unwrap())
     }
-
 }
 
 impl Display for KeyValueStore {

--- a/kvx/src/lib.rs
+++ b/kvx/src/lib.rs
@@ -104,11 +104,7 @@ impl KeyValueStore {
         Ok(KeyValueStore { inner })
     }
 
-    pub fn execute<F, T>(
-        &self,
-        scope: &Scope,
-        mut op: F
-    ) -> Result<T>
+    pub fn execute<F, T>(&self, scope: &Scope, mut op: F) -> Result<T>
     where F: FnMut(&dyn KeyValueStoreBackend) -> Result<T, Error>  {
         let mut res = None;
         self.transaction(scope, &mut |store| {


### PR DESCRIPTION
This PR adds a method `KeyValueStore::execute` that runs a closure as a transaction but allowing it to return a closure.