### PR TITLE
Remove cargo fmt --check (using nightly) in GH workflow.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,10 +45,8 @@ jobs:
       - run: |
           rustup toolchain install nightly --profile minimal
           rustup default nightly
-          rustup component add rustfmt
       - run: cargo install cargo-udeps || true
       - run: |
-          cargo fmt --check
           cargo udeps --all-features --all-targets
 
   test:


### PR DESCRIPTION
Especially being done on nightly this can result in the build failing for unrelated reasons. I opt for just keeping some discipline in formatting manually and/or running `cargo fmt` (stable) from time to time.