### PR TITLE
Support namespace migrations

### DIFF
--- a/kvx-types/src/scope.rs
+++ b/kvx-types/src/scope.rs
@@ -204,7 +204,7 @@ impl<'a> IntoIterator for &'a Scope {
 
 impl Extend<SegmentBuf> for Scope {
     fn extend<T: IntoIterator<Item = SegmentBuf>>(&mut self, iter: T) {
-        self.segments.extend(iter.into_iter())
+        self.segments.extend(iter)
     }
 }
 

--- a/kvx/src/error.rs
+++ b/kvx/src/error.rs
@@ -45,4 +45,8 @@ pub enum Error {
     /// [`Key`]: ../kvx/struct.Key.html
     #[error("unknown key")]
     UnknownKey,
+
+    /// Namespace migration issue
+    #[error("namespace migration issue: {0}")]
+    NamespaceMigration(String),
 }

--- a/kvx/src/implementations/disk.rs
+++ b/kvx/src/implementations/disk.rs
@@ -29,7 +29,7 @@ impl Disk {
 
 impl Display for Disk {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "KeyValueStore::Disk({})", self.root.to_string_lossy())
+        write!(f, "KeyValueStore::Disk({})", self.root.display())
     }
 }
 
@@ -156,33 +156,42 @@ impl WriteStore for Disk {
     fn migrate_namespace(&mut self, namespace: kvx_types::NamespaceBuf) -> Result<()> {
         let root_parent = self.root.parent().ok_or(Error::NamespaceMigration(format!(
             "cannot get parent dir for: {}",
-            self.root.to_string_lossy()
+            self.root.display()
         )))?;
 
         let new_root = root_parent.join(namespace.as_str());
 
-        let new_root_is_empty = new_root
-            .read_dir()
-            .map(|mut d| d.next().is_none())
-            .unwrap_or(true);
-
-        if !new_root_is_empty {
-            Err(Error::NamespaceMigration(format!(
-                "new target dir already exists and is not empty at: {}",
-                new_root.to_string_lossy(),
-            )))
-        } else {
-            fs::rename(&self.root, &new_root).map_err(|e| {
-                Error::NamespaceMigration(format!(
-                    "cannot rename dir from {} to {}. Error: {}",
-                    self.root.to_string_lossy(),
-                    new_root.to_string_lossy(),
-                    e
-                ))
-            })?;
-            self.root = new_root;
-            Ok(())
+        if new_root.exists() {
+            // If the target directory already exists, then it must be empty.
+            if new_root
+                .read_dir()
+                .map_err(|e| {
+                    Error::NamespaceMigration(format!(
+                        "cannot read directory '{}'. Error: {}",
+                        new_root.display(),
+                        e,
+                    ))
+                })?
+                .next()
+                .is_some()
+            {
+                return Err(Error::NamespaceMigration(format!(
+                    "target dir {} already exists and is not empty",
+                    new_root.display(),
+                )));
+            }
         }
+
+        fs::rename(&self.root, &new_root).map_err(|e| {
+            Error::NamespaceMigration(format!(
+                "cannot rename dir from {} to {}. Error: {}",
+                self.root.display(),
+                new_root.display(),
+                e
+            ))
+        })?;
+        self.root = new_root;
+        Ok(())
     }
 }
 

--- a/kvx/src/implementations/disk.rs
+++ b/kvx/src/implementations/disk.rs
@@ -23,9 +23,6 @@ pub struct Disk {
 impl Disk {
     pub fn new(path: &str, namespace: &str) -> Result<Self> {
         let root = PathBuf::from(path).join(namespace);
-        if !root.try_exists().unwrap_or_default() {
-            fs::create_dir_all(&root)?;
-        }
         Ok(Disk { root })
     }
 }
@@ -37,6 +34,14 @@ impl Display for Disk {
 }
 
 impl ReadStore for Disk {
+    fn is_empty(&self) -> Result<bool> {
+        Ok(self
+            .root
+            .read_dir()
+            .map(|mut d| d.next().is_none())
+            .unwrap_or(true))
+    }
+
     fn has(&self, key: &Key) -> Result<bool> {
         let exists = key.as_path(&self.root).exists();
         Ok(exists)

--- a/kvx/src/implementations/disk.rs
+++ b/kvx/src/implementations/disk.rs
@@ -160,9 +160,15 @@ impl WriteStore for Disk {
         )))?;
 
         let new_root = root_parent.join(namespace.as_str());
-        if new_root.exists() {
+
+        let new_root_is_empty = new_root
+            .read_dir()
+            .map(|mut d| d.next().is_none())
+            .unwrap_or(true);
+
+        if !new_root_is_empty {
             Err(Error::NamespaceMigration(format!(
-                "new target dir already exists at: {}",
+                "new target dir already exists and is not empty at: {}",
                 new_root.to_string_lossy(),
             )))
         } else {

--- a/kvx/src/implementations/memory.rs
+++ b/kvx/src/implementations/memory.rs
@@ -149,6 +149,7 @@ lazy_static! {
 
 #[derive(Debug)]
 pub(crate) struct Memory {
+    // Used to prevent namespace collisions in the shared (lazy static) in memory structure.
     namespace_prefix: Option<String>,
     effective_namespace: NamespaceBuf,
     inner: &'static Mutex<MemoryStore>,
@@ -320,6 +321,9 @@ impl WriteStore for Memory {
     }
 
     fn migrate_namespace(&mut self, to: NamespaceBuf) -> Result<()> {
+        // We need to preserve the namespace prefix if it was set.
+        // This prefix is used to prevent namespace collisions in the
+        // shared (lazy static) in memory structure.
         let effective_to = Self::effective_namespace(&self.namespace_prefix, to)?;
 
         self.lock()?

--- a/kvx/src/implementations/memory.rs
+++ b/kvx/src/implementations/memory.rs
@@ -122,11 +122,13 @@ pub(crate) struct Memory {
 
 impl Memory {
     pub(crate) fn new(namespace: impl Into<NamespaceBuf>) -> Self {
-        Memory {
+        let res = Memory {
             namespace: namespace.into(),
             inner: &STORE,
             locks: &LOCKS,
-        }
+        };
+        res.clear().unwrap();
+        res
     }
 
     pub(super) fn lock(&self) -> Result<MutexGuard<'_, MemoryStore>> {

--- a/kvx/src/implementations/memory.rs
+++ b/kvx/src/implementations/memory.rs
@@ -24,7 +24,7 @@ impl MemoryStore {
         self.0
             .get(namespace)
             .map(|m| m.contains_key(key))
-            .unwrap_or_default()
+            .unwrap_or(false)
     }
 
     fn namespace_is_empty(&self, namespace: &NamespaceBuf) -> bool {

--- a/kvx/src/implementations/memory.rs
+++ b/kvx/src/implementations/memory.rs
@@ -116,9 +116,9 @@ impl MemoryStore {
     }
 
     fn migrate_namespace(&mut self, from: &NamespaceBuf, to: &NamespaceBuf) -> Result<()> {
-        if self.0.contains_key(to) {
+        if !self.namespace_is_empty(to) {
             Err(Error::NamespaceMigration(format!(
-                "target in-memory namespace {} already exists",
+                "target in-memory namespace {} is not empty",
                 to.as_str()
             )))
         } else {

--- a/kvx/src/implementations/memory.rs
+++ b/kvx/src/implementations/memory.rs
@@ -27,10 +27,7 @@ impl MemoryStore {
     }
 
     fn namespace_is_empty(&self, namespace: &NamespaceBuf) -> bool {
-        self.0
-            .get(namespace)
-            .map(|m| m.is_empty())
-            .unwrap_or_default()
+        self.0.get(namespace).map(|m| m.is_empty()).unwrap_or(true)
     }
 
     fn has_scope(&self, namespace: &NamespaceBuf, scope: &Scope) -> bool {

--- a/kvx/src/implementations/memory.rs
+++ b/kvx/src/implementations/memory.rs
@@ -151,13 +151,11 @@ pub(crate) struct Memory {
 
 impl Memory {
     pub(crate) fn new(namespace: impl Into<NamespaceBuf>) -> Self {
-        let res = Memory {
+        Memory {
             namespace: namespace.into(),
             inner: &STORE,
             locks: &LOCKS,
-        };
-        res.clear().unwrap();
-        res
+        }
     }
 
     pub(super) fn lock(&self) -> Result<MutexGuard<'_, MemoryStore>> {

--- a/kvx/src/implementations/mod.rs
+++ b/kvx/src/implementations/mod.rs
@@ -226,6 +226,14 @@ mod tests {
         store.clear().unwrap();
     }
 
+    fn test_is_empty(store: impl KeyValueStoreBackend) {
+        assert!(store.is_empty().unwrap());
+
+        store.store(&random_key(1), random_value(8)).unwrap();
+
+        assert!(!store.is_empty().unwrap());
+    }
+
     fn test_move_scope(store: impl KeyValueStoreBackend) {
         let key = random_key(0);
         let scope = random_scope(1);
@@ -449,6 +457,12 @@ mod tests {
                 #[serial]
                 fn test_clear() {
                     super::test_clear($construct(super::random_namespace()))
+                }
+
+                #[test]
+                #[serial]
+                fn test_is_empty() {
+                    super::test_is_empty($construct(super::random_namespace()))
                 }
 
                 #[test]

--- a/kvx/src/implementations/mod.rs
+++ b/kvx/src/implementations/mod.rs
@@ -136,8 +136,7 @@ mod tests {
             .unwrap();
 
         let mut result = store.list_scopes().unwrap();
-        let mut expected =
-            vec![scope.sub_scopes(), scope1.sub_scopes(), scope2.sub_scopes()].concat();
+        let mut expected = [scope.sub_scopes(), scope1.sub_scopes(), scope2.sub_scopes()].concat();
 
         result.sort();
         expected.sort();
@@ -332,7 +331,7 @@ mod tests {
 
                     let mut result: Vec<Key> =
                         store.list_keys(&scope_clone).unwrap().into_iter().collect();
-                    let expected: Vec<Key> = vec![
+                    let expected: Vec<Key> = [
                         format!("key_{index}_1_{counter}"),
                         format!("key_{index}_2_{counter}"),
                         format!("key_{index}_3_{counter}"),
@@ -360,7 +359,7 @@ mod tests {
             .into_iter()
             .collect();
 
-        let scenario1: Vec<Key> = vec![
+        let scenario1: Vec<Key> = [
             "key_0_1_0",
             "key_0_2_0",
             "key_0_3_0",
@@ -374,7 +373,7 @@ mod tests {
         .map(|s| Key::new_scoped(transaction_scope.clone(), s.parse::<SegmentBuf>().unwrap()))
         .collect();
 
-        let scenario2: Vec<Key> = vec![
+        let scenario2: Vec<Key> = [
             "key_0_1_1",
             "key_0_2_1",
             "key_0_3_1",

--- a/kvx/src/implementations/mod.rs
+++ b/kvx/src/implementations/mod.rs
@@ -483,11 +483,13 @@ mod tests {
     }
 
     fn memory(namespace: NamespaceBuf) -> Memory {
+        use crate::WriteStore;
+        
         let store = Memory::new(namespace);
-        store.lock().unwrap().clear();
+        store.clear().unwrap();
         store
     }
-
+    
     fn disk(namespace: NamespaceBuf) -> Disk {
         let cwd = std::env::current_dir().unwrap().join("data");
         let path = cwd.to_str().unwrap();

--- a/kvx/src/implementations/mod.rs
+++ b/kvx/src/implementations/mod.rs
@@ -498,7 +498,7 @@ mod tests {
     fn memory(namespace: NamespaceBuf) -> Memory {
         use crate::WriteStore;
 
-        let store = Memory::new(namespace);
+        let store = Memory::new(None, namespace).unwrap();
         store.clear().unwrap();
         store
     }

--- a/kvx/src/implementations/mod.rs
+++ b/kvx/src/implementations/mod.rs
@@ -484,12 +484,12 @@ mod tests {
 
     fn memory(namespace: NamespaceBuf) -> Memory {
         use crate::WriteStore;
-        
+
         let store = Memory::new(namespace);
         store.clear().unwrap();
         store
     }
-    
+
     fn disk(namespace: NamespaceBuf) -> Disk {
         let cwd = std::env::current_dir().unwrap().join("data");
         let path = cwd.to_str().unwrap();

--- a/kvx/src/implementations/postgres.rs
+++ b/kvx/src/implementations/postgres.rs
@@ -85,6 +85,19 @@ impl<E: HasExecutor> KeyValueStoreBackend for Postgres<E> {
 }
 
 impl<E: HasExecutor> ReadStore for Postgres<E> {
+    fn is_empty(&self) -> Result<bool> {
+        // We use a shared table for multiple namespaces. We consider this
+        // instance empty if there are no entries for this namespace.
+        Ok(self
+            .executor
+            .executor()?
+            .exec_query_opt(
+                "SELECT 1 FROM store WHERE namespace = $1",
+                &[&self.namespace],
+            )?
+            .is_none())
+    }
+
     fn has(&self, key: &Key) -> Result<bool> {
         Ok(self
             .executor

--- a/kvx/src/implementations/postgres.rs
+++ b/kvx/src/implementations/postgres.rs
@@ -145,9 +145,7 @@ impl<E: HasExecutor> ReadStore for Postgres<E> {
                 &[&self.namespace],
             )?
             .into_iter()
-            .flat_map(|row| {
-                Scope::new(row.get(0)).sub_scopes()
-            })
+            .flat_map(|row| Scope::new(row.get(0)).sub_scopes())
             .collect::<Vec<Scope>>())
     }
 }

--- a/kvx/src/implementations/postgres.rs
+++ b/kvx/src/implementations/postgres.rs
@@ -114,7 +114,7 @@ impl<E: HasExecutor> ReadStore for Postgres<E> {
             .executor
             .executor()?
             .exec_query_opt(
-                "SELECT 1 FROM store WHERE namespace = $1 AND scope[:$3]  = $2",
+                "SELECT DISTINCT scope FROM store WHERE namespace = $1 AND scope[:$3]  = $2",
                 &[&self.namespace, scope.as_vec(), &scope.len()],
             )?
             .is_some())

--- a/kvx/src/implementations/postgres.rs
+++ b/kvx/src/implementations/postgres.rs
@@ -92,7 +92,7 @@ impl<E: HasExecutor> ReadStore for Postgres<E> {
             .executor
             .executor()?
             .exec_query_opt(
-                "SELECT 1 FROM store WHERE namespace = $1",
+                "SELECT DISTINCT namespace FROM store WHERE namespace = $1",
                 &[&self.namespace],
             )?
             .is_none())

--- a/kvx/src/lib.rs
+++ b/kvx/src/lib.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Display};
 
 use implementations::{disk::Disk, memory::Memory};
 #[cfg(feature = "macros")]
-pub use kvx_macros::segment;
+pub use kvx_macros::{namespace, segment};
 pub use kvx_types::{Key, Namespace, NamespaceBuf, Scope, Segment, SegmentBuf};
 #[cfg(feature = "queue")]
 pub use queue::Queue;

--- a/kvx/src/lib.rs
+++ b/kvx/src/lib.rs
@@ -20,6 +20,7 @@ pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// Read operations of a store
 pub trait ReadStore {
+    fn is_empty(&self) -> Result<bool>;
     fn has(&self, key: &Key) -> Result<bool>;
     fn has_scope(&self, scope: &Scope) -> Result<bool>;
     fn get(&self, key: &Key) -> Result<Option<Value>>;
@@ -143,6 +144,10 @@ impl KeyValueStoreBackend for KeyValueStore {
 }
 
 impl ReadStore for KeyValueStore {
+    fn is_empty(&self) -> Result<bool> {
+        self.inner.is_empty()
+    }
+
     fn has(&self, key: &Key) -> Result<bool> {
         self.inner.has(key)
     }

--- a/kvx/src/lib.rs
+++ b/kvx/src/lib.rs
@@ -86,7 +86,7 @@ impl KeyValueStore {
             }
             "memory" => Box::new(Memory::new(
                 format!(
-                    "{} {}",
+                    "{}_{}",
                     storage_uri.host_str().unwrap_or_default(),
                     namespace
                 )

--- a/kvx/src/lib.rs
+++ b/kvx/src/lib.rs
@@ -98,15 +98,7 @@ impl KeyValueStore {
 
                 Box::new(Disk::new(&path, namespace.as_str())?)
             }
-            "memory" => Box::new(Memory::new(
-                format!(
-                    "{}_{}",
-                    storage_uri.host_str().unwrap_or_default(),
-                    namespace
-                )
-                .parse()
-                .unwrap_or(namespace),
-            )),
+            "memory" => Box::new(Memory::new(storage_uri.host_str(), namespace)?),
             #[cfg(feature = "postgres")]
             "postgres" => Box::new(crate::implementations::postgres::Postgres::new(
                 storage_uri,

--- a/kvx/src/lib.rs
+++ b/kvx/src/lib.rs
@@ -27,15 +27,28 @@ pub trait ReadStore {
     fn list_scopes(&self) -> Result<Vec<Scope>>;
 }
 
-/// Read operations of a store
+/// Write operations of a store
 pub trait WriteStore {
+    /// Store a value.
     fn store(&self, key: &Key, value: Value) -> Result<()>;
+
+    /// Move a value to a new key. Fails if the original value does not exist.
     fn move_value(&self, from: &Key, to: &Key) -> Result<()>;
+
+    /// Move all values from one scope to another.
     fn move_scope(&self, from: &Scope, to: &Scope) -> Result<()>;
 
+    /// Delete a value for a key.
     fn delete(&self, key: &Key) -> Result<()>;
+
+    /// Delete all values for a scope.
     fn delete_scope(&self, scope: &Scope) -> Result<()>;
+
+    /// Delete all values within the namespace of this store.
     fn clear(&self) -> Result<()>;
+
+    /// Migrate the namespace (and all key value pairs) for this store.
+    fn migrate_namespace(&mut self, to: NamespaceBuf) -> Result<()>;
 }
 
 pub(crate) type TransactionCallback<'s> =
@@ -174,5 +187,9 @@ impl WriteStore for KeyValueStore {
 
     fn clear(&self) -> Result<()> {
         self.inner.clear()
+    }
+
+    fn migrate_namespace(&mut self, to: NamespaceBuf) -> Result<()> {
+        self.inner.migrate_namespace(to)
     }
 }


### PR DESCRIPTION
Needed by Krill for disk agnostic migrations. This helps to support preparing data in a dedicated 'upgrade' namespace first, and then migrating namespaces when the upgrade is done.