### PR TITLE
Support different behaviours if a task already exists. #34

### DIFF
--- a/kvx/src/lib.rs
+++ b/kvx/src/lib.rs
@@ -4,8 +4,6 @@ use implementations::{disk::Disk, memory::Memory};
 #[cfg(feature = "macros")]
 pub use kvx_macros::{namespace, segment};
 pub use kvx_types::{Key, Namespace, NamespaceBuf, Scope, Segment, SegmentBuf};
-#[cfg(feature = "queue")]
-pub use queue::Queue;
 use serde_json::Value;
 use url::Url;
 
@@ -14,7 +12,7 @@ pub use crate::error::Error;
 mod error;
 mod implementations;
 #[cfg(feature = "queue")]
-mod queue;
+pub mod queue;
 
 pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 

--- a/kvx/src/queue.rs
+++ b/kvx/src/queue.rs
@@ -329,7 +329,6 @@ impl Queue for KeyValueStore {
                 .min_by_key(|tk| tk.timestamp)
             {
                 let pending_key = pending.pending_key();
-                let running_key = pending.running_key();
 
                 if let Some(value) = kv.get(&pending_key)? {
                     let running_task = RunningTask {
@@ -337,6 +336,7 @@ impl Queue for KeyValueStore {
                         timestamp: now,
                         value,
                     };
+                    let running_key = Key::from(&running_task);
 
                     kv.move_value(&pending_key, &running_key)?;
 

--- a/kvx/src/queue.rs
+++ b/kvx/src/queue.rs
@@ -1,5 +1,7 @@
 use std::{
+    borrow::Cow,
     fmt::{Display, Formatter},
+    str::FromStr,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -7,72 +9,79 @@ use crate::{
     segment, Error, Key, KeyValueStore, KeyValueStoreBackend, Result, Scope, Segment, SegmentBuf,
 };
 
-fn current_time() -> u64 {
+const SEPARATOR: char = '-';
+
+fn now() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("time-travel is not supported")
         .as_secs()
 }
 
-#[derive(Clone, Debug)]
-enum TaskState {
-    Pending(PendingTask),
-    Running(RunningTask),
-    Finished(FinishedTask),
+struct TaskKey<'a> {
+    pub name: Cow<'a, SegmentBuf>,
+    pub timestamp: u64,
 }
 
-impl TaskState {
-    pub const SEPARATOR: char = '-';
-}
+impl<'a> TaskKey<'a> {
+    fn key(&self) -> Key {
+        Key::from_str(&format!("{}{}{}", self.timestamp, SEPARATOR, self.name)).unwrap()
+    }
 
-impl TaskState {
-    fn super_scope(&self) -> &Segment {
-        match self {
-            TaskState::Pending(_) => PendingTask::SEGMENT,
-            TaskState::Running(_) => RunningTask::SEGMENT,
-            TaskState::Finished(_) => FinishedTask::SEGMENT,
-        }
+    fn running_key(&self) -> Key {
+        let mut key = self.key();
+        key.add_super_scope(RunningTask::SEGMENT);
+        key
+    }
+
+    fn pending_key(&self) -> Key {
+        let mut key = self.key();
+        key.add_super_scope(PendingTask::SEGMENT);
+        key
     }
 }
 
-impl From<TaskState> for Key {
-    fn from(task: TaskState) -> Self {
-        let mut name: Key = match task.clone() {
-            TaskState::Pending(t) => t.to_string().parse().unwrap(),
-            TaskState::Running(t) => t.to_string().parse().unwrap(),
-            TaskState::Finished(t) => t.to_string().parse().unwrap(),
-        };
-
-        name.add_super_scope(task.super_scope());
-
-        name
-    }
-}
-
-#[derive(Clone, Debug)]
-struct PendingTask {
-    pub name: SegmentBuf,
-    pub schedule_timestamp: u64,
-}
-
-impl PendingTask {
-    const SEGMENT: &Segment = segment!("pending");
-}
-
-impl TryFrom<Key> for PendingTask {
+impl TryFrom<Key> for TaskKey<'_> {
     type Error = Error;
 
     fn try_from(key: Key) -> Result<Self, Self::Error> {
         let (ts, name) = key
             .name()
             .as_str()
-            .split_once(TaskState::SEPARATOR)
+            .split_once(SEPARATOR)
             .ok_or(Error::InvalidKey)?;
-        Ok(PendingTask {
-            name: Segment::parse(name)?.into(),
-            schedule_timestamp: ts.parse().map_err(|_| Error::InvalidKey)?,
+        Ok(TaskKey {
+            name: Cow::Owned(Segment::parse(name)?.into()),
+            timestamp: ts.parse().map_err(|_| Error::InvalidKey)?,
         })
     }
+}
+
+impl From<&PendingTask> for Key {
+    fn from(p: &PendingTask) -> Self {
+        let mut key = Key::from_str(&p.to_string()).unwrap();
+        key.add_super_scope(PendingTask::SEGMENT);
+        key
+    }
+}
+
+impl From<&RunningTask> for Key {
+    fn from(p: &RunningTask) -> Self {
+        let mut key = Key::from_str(&p.to_string()).unwrap();
+        key.add_super_scope(RunningTask::SEGMENT);
+        key
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PendingTask {
+    pub name: SegmentBuf,
+    pub timestamp: u64,
+    pub value: serde_json::Value,
+}
+
+impl PendingTask {
+    const SEGMENT: &Segment = segment!("pending");
 }
 
 impl PartialEq for PendingTask {
@@ -86,37 +95,22 @@ impl Display for PendingTask {
         write!(
             f,
             "{}{}{}",
-            self.schedule_timestamp,
-            TaskState::SEPARATOR.encode_utf8(&mut [0; 4]),
+            self.timestamp,
+            SEPARATOR.encode_utf8(&mut [0; 4]),
             self.name,
         )
     }
 }
 
 #[derive(Clone, Debug)]
-struct RunningTask {
-    pub task_name: PendingTask,
-    pub claim_timestamp: u64,
+pub struct RunningTask {
+    pub name: SegmentBuf,
+    pub timestamp: u64,
+    pub value: serde_json::Value,
 }
 
 impl RunningTask {
     const SEGMENT: &Segment = segment!("running");
-}
-
-impl TryFrom<Key> for RunningTask {
-    type Error = Error;
-
-    fn try_from(key: Key) -> Result<Self, Self::Error> {
-        let (ts, name) = key
-            .name()
-            .as_str()
-            .split_once(TaskState::SEPARATOR)
-            .ok_or(Error::InvalidKey)?;
-        Ok(RunningTask {
-            task_name: PendingTask::try_from(name.parse::<Key>()?)?,
-            claim_timestamp: ts.parse().map_err(|_| Error::InvalidKey)?,
-        })
-    }
 }
 
 impl Display for RunningTask {
@@ -124,106 +118,62 @@ impl Display for RunningTask {
         write!(
             f,
             "{}{}{}",
-            self.claim_timestamp,
-            TaskState::SEPARATOR.encode_utf8(&mut [0; 4]),
-            self.task_name,
-        )
-    }
-}
-
-#[derive(Clone, Debug)]
-struct FinishedTask {
-    pub name: PendingTask,
-    pub finish_timestamp: u64,
-}
-
-impl FinishedTask {
-    const SEGMENT: &Segment = segment!("finished");
-}
-
-impl TryFrom<Key> for FinishedTask {
-    type Error = Error;
-
-    fn try_from(key: Key) -> Result<Self, Self::Error> {
-        let (ts, name) = key
-            .name()
-            .as_str()
-            .split_once(TaskState::SEPARATOR)
-            .ok_or(Error::InvalidKey)?;
-        Ok(FinishedTask {
-            name: PendingTask::try_from(name.parse::<Key>()?)?,
-            finish_timestamp: ts.parse().map_err(|_| Error::InvalidKey)?,
-        })
-    }
-}
-
-impl Display for FinishedTask {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}{}{}",
-            self.finish_timestamp,
-            TaskState::SEPARATOR.encode_utf8(&mut [0; 4]),
+            self.timestamp,
+            SEPARATOR.encode_utf8(&mut [0; 4]),
             self.name,
         )
     }
 }
 
-/// Defines a task which may be pending, running or finished.
-#[derive(Clone, Debug)]
-pub struct Task {
-    state: TaskState,
-    pub value: serde_json::Value,
-}
-
-impl Task {
-    pub fn name(&self) -> &Segment {
-        self.state.super_scope()
-    }
-}
-
-/// Defines a task which is optionally used to reschedule a finished task.
-///
-/// Takes the name from the finished task. A new value can be specified. If
-/// it is omitted then the value from the finished task will be re-used.
-#[derive(Clone, Debug)]
-pub struct RescheduledTask {
-    pub new_value: Option<serde_json::Value>,
-    pub schedule_timestamp: u64,
-}
-
 /// Defines scheduling behaviour in case a task by the same name already exists.
 #[derive(Clone, Copy, Debug)]
 pub enum Existing {
-    /// Reschedule existing, keeping the old value and ignoring the new value.
-    ///
-    /// NOTE: If the new value should be used, then use KeepNew instead.
-    RescheduleToNewTime,
     /// Store new task, replace old task if it exists.
     KeepNew,
     /// Store new task, replace old task if it exists, keep the soonest
     /// scheduled time.
     KeepNewScheduleSoonest,
-    /// Keep existing, discard new.
-    KeepOld,
-    /// Keep existing and add new.
+    /// Reschedule existing, keeping the old value and ignoring the new value.
     ///
-    /// NOTE: The task key is determined by its name and scheduled time.
-    ///       If both the existing and the new scheduled time are the
-    ///       same, then this results in replacing the existing task.
-    KeepBoth,
+    /// Note: If the new value should be used, then use KeepNew instead.
+    KeepOldWithNewTime,
+    /// Keep existing, discard new.
+    ///
+    /// Note: Can be used to schedule a task only in case it's missing.
+    KeepOld,
+}
+
+/// Defines scheduling behaviour in case a task by the same name is running.
+#[derive(Clone, Copy, Debug)]
+pub enum Running {
+    /// Finish the running task if it exists.
+    Finish,
+    /// Keep the running task if it exists.
+    Keep,
+}
+
+impl Running {
+    pub fn must_be_finished(&self) -> bool {
+        matches!(self, Running::Finish)
+    }
 }
 
 pub trait Queue {
     const RESCHEDULE_AFTER: Duration = Duration::from_secs(15 * 60);
-    const REMOVE_AFTER: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 
     fn pending_scope() -> Scope {
         Scope::from_segment(PendingTask::SEGMENT)
     }
 
+    fn running_scope() -> Scope {
+        Scope::from_segment(RunningTask::SEGMENT)
+    }
+
     /// Returns the number of pending tasks remaining
     fn pending_tasks_remaining(&self) -> Result<usize>;
+
+    /// Returns the number of running tasks
+    fn running_tasks(&self) -> Result<usize>;
 
     /// Schedule a task.
     fn schedule_task(
@@ -231,27 +181,21 @@ pub trait Queue {
         name: SegmentBuf,
         value: serde_json::Value,
         timestamp: Option<u64>,
-        mode: Existing,
+        existing: Existing,
+        running: Running,
     ) -> Result<()>;
 
     /// Returns the scheduled time for the named task, if any.
     fn pending_task_scheduled(&self, name: SegmentBuf) -> Result<Option<u64>>;
 
     /// Marks a running task as finished. Fails if the task is not running.
-    fn finish_running_task(
-        &self,
-        task: Task,
-        rescheduled_task: Option<RescheduledTask>,
-    ) -> Result<()>;
+    fn finish_running_task(&self, running: RunningTask) -> Result<()>;
 
     /// Claims the next scheduled pending task, if any.
-    fn claim_scheduled_pending_task(&self) -> Result<Option<Task>>;
+    fn claim_scheduled_pending_task(&self) -> Result<Option<RunningTask>>;
 
     /// Reschedules running tasks that have timed out.
     fn reschedule_long_running_tasks(&self, reschedule_after: Option<&Duration>) -> Result<()>;
-
-    /// Cleans finished tasks.
-    fn clean_up_finished_tasks(&self, remove_after: Option<&Duration>) -> Result<()>;
 }
 
 impl Queue for KeyValueStore {
@@ -261,144 +205,125 @@ impl Queue for KeyValueStore {
         })
     }
 
+    fn running_tasks(&self) -> Result<usize> {
+        self.execute(&Self::pending_scope(), |kv| {
+            kv.list_keys(&Self::running_scope()).map(|list| list.len())
+        })
+    }
+
     fn schedule_task(
         &self,
         name: SegmentBuf,
         value: serde_json::Value,
         timestamp: Option<u64>,
-        mode: Existing,
+        mode_existing: Existing,
+        running: Running,
     ) -> Result<()> {
         let mut new_task = PendingTask {
             name,
-            schedule_timestamp: timestamp.unwrap_or(current_time()),
+            timestamp: timestamp.unwrap_or(now()),
+            value,
         };
+        let new_task_key = Key::from(&new_task);
 
         self.transaction(
             &Scope::global(),
             &mut move |s: &dyn KeyValueStoreBackend| {
-                let possible_existing: Option<PendingTask> = s
+                // Finish the matching running task (if any) if requested
+                // to do so.
+                if running.must_be_finished() {
+                    if let Some(running) = s
+                        .list_keys(&Scope::from_segment(RunningTask::SEGMENT))?
+                        .into_iter()
+                        .filter_map(|k| TaskKey::try_from(k).ok())
+                        .find(|running| running.name.as_ref() == &new_task.name)
+                        .map(|tk| tk.running_key())
+                    {
+                        s.delete(&running)?;
+                    }
+                }
+
+                // If there is an existing pending task for this,
+                // then we need to figure out what to do with it.
+                if let Some(existing) = s
                     .list_keys(&Scope::from_segment(PendingTask::SEGMENT))?
                     .into_iter()
-                    .filter_map(|k| PendingTask::try_from(k).ok())
-                    .find(|p| p.name == new_task.name);
+                    .filter_map(|k| TaskKey::try_from(k).ok())
+                    .find(|p| p.name.as_ref() == &new_task.name)
+                {
+                    let pending_key = existing.pending_key();
 
-                if let Some(existing) = possible_existing {
-                    match mode {
+                    match mode_existing {
                         Existing::KeepOld => {
                             // nothing to do
                             Ok(())
                         }
-                        Existing::KeepBoth => {
-                            // just save the new task, possibly overwriting the
-                            // existing task if the name and scheduled time are
-                            // the same
-                            s.store(&TaskState::Pending(new_task.clone()).into(), value.clone())
-                        }
-                        Existing::RescheduleToNewTime => {
+                        Existing::KeepOldWithNewTime => {
                             // reschedule existing task
-                            s.move_value(
-                                &TaskState::Pending(existing).into(),
-                                &TaskState::Pending(new_task.clone()).into(),
-                            )
+                            // note that the due time is part of the key, not the content
+                            s.move_value(&pending_key, &new_task_key)
                         }
                         Existing::KeepNew => {
-                            s.delete(&TaskState::Pending(existing).into())?;
-                            s.store(&TaskState::Pending(new_task.clone()).into(), value.clone())
+                            s.delete(&pending_key)?;
+                            s.store(&new_task_key, new_task.value.clone())
                         }
                         Existing::KeepNewScheduleSoonest => {
-                            new_task.schedule_timestamp =
-                                new_task.schedule_timestamp.min(existing.schedule_timestamp);
-                            s.delete(&TaskState::Pending(existing).into())?;
-                            s.store(&TaskState::Pending(new_task.clone()).into(), value.clone())
+                            new_task.timestamp = new_task.timestamp.min(existing.timestamp);
+
+                            let new_task_key = Key::from(&new_task);
+                            s.delete(&pending_key)?;
+                            s.store(&new_task_key, new_task.value.clone())
                         }
                     }
                 } else {
-                    // store new task
-                    s.store(&TaskState::Pending(new_task.clone()).into(), value.clone())
+                    // There was no matching pending task, just store
+                    // this new task.
+                    s.store(&new_task_key, new_task.value.clone())
                 }
             },
         )
     }
 
-    fn finish_running_task(&self, task: Task, rescheduled: Option<RescheduledTask>) -> Result<()> {
-        let finish_timestamp = current_time();
-        match task.state.clone() {
-            TaskState::Running(RunningTask { task_name, .. }) => {
-                let finished = TaskState::Finished(FinishedTask {
-                    name: task_name,
-                    finish_timestamp,
-                });
+    fn finish_running_task(&self, running: RunningTask) -> Result<()> {
+        let running_key = Key::from(&running);
 
-                let running: Key = task.state.into();
-                let finished: Key = finished.into();
+        // The scopes for running and finished differ, so we need a global lock
+        let lock_scope = Scope::global();
 
-                // Note in this case, the scopes differ, so we need a global lock
-                let lock_scope = Scope::global();
-
-                let pending = rescheduled.map(|r| {
-                    (
-                        TaskState::Pending(PendingTask {
-                            name: running.name().to_owned(),
-                            schedule_timestamp: r.schedule_timestamp,
-                        }),
-                        r.new_value,
-                    )
-                });
-
-                self.execute(&lock_scope, move |kv| {
-                    if let Some((pending, value_opt)) = pending.clone() {
-                        let pending_key: Key = pending.into();
-                        let value = match value_opt {
-                            Some(value) => value,
-                            None => kv.get(&running)?.ok_or(Error::Other(format!(
-                                "cannot find existing value for rescheduling task: {}",
-                                pending_key
-                            )))?,
-                        };
-
-                        kv.store(&pending_key, value)?;
-                    }
-
-                    kv.move_value(&running, &finished)?;
-                    Ok(())
-                })
+        self.execute(&lock_scope, |kv| {
+            if kv.has(&running_key)? {
+                kv.delete(&running_key)
+            } else {
+                Err(Error::Other(format!(
+                    "Cannot finish task {}. It is not running.",
+                    &running_key
+                )))
             }
-            _ => Err(Error::Other(format!(
-                "Cannot finish task {}. It is not running.",
-                task.name()
-            ))),
-        }
+        })
     }
 
-    fn claim_scheduled_pending_task(&self) -> Result<Option<Task>> {
+    fn claim_scheduled_pending_task(&self) -> Result<Option<RunningTask>> {
         self.execute(&Scope::global(), |kv| {
-            let now = current_time();
-            let keys = kv.list_keys(&Scope::from_segment(PendingTask::SEGMENT))?;
+            let now = now();
 
-            let candidate = keys
+            if let Some(pending) = kv
+                .list_keys(&Scope::from_segment(PendingTask::SEGMENT))?
                 .into_iter()
-                .filter_map(|k| {
-                    let task = PendingTask::try_from(k).ok()?;
-                    if task.schedule_timestamp <= now {
-                        Some(task)
-                    } else {
-                        None
-                    }
-                })
-                .min_by_key(|s| s.schedule_timestamp);
+                .filter_map(|k| TaskKey::try_from(k).ok())
+                .filter(|tk| tk.timestamp <= now)
+                .min_by_key(|tk| tk.timestamp)
+            {
+                let pending_key = pending.pending_key();
+                let running_key = pending.running_key();
 
-            if let Some(name) = candidate {
-                let pending = TaskState::Pending(name.clone());
-                if let Some(value) = kv.get(&pending.clone().into())? {
-                    let running_task = Task {
-                        state: TaskState::Running(RunningTask {
-                            task_name: name,
-                            claim_timestamp: now,
-                        }),
+                if let Some(value) = kv.get(&pending_key)? {
+                    let running_task = RunningTask {
+                        name: pending.name.into_owned(),
+                        timestamp: now,
                         value,
                     };
 
-                    kv.move_value(&pending.into(), &running_task.state.clone().into())?;
+                    kv.move_value(&pending_key, &running_key)?;
 
                     Ok(Some(running_task))
                 } else {
@@ -411,7 +336,7 @@ impl Queue for KeyValueStore {
     }
 
     fn reschedule_long_running_tasks(&self, reschedule_after: Option<&Duration>) -> Result<()> {
-        let now = current_time();
+        let now = now();
 
         let reschedule_after = reschedule_after.unwrap_or(&KeyValueStore::RESCHEDULE_AFTER);
         let reschedule_timeout = now - reschedule_after.as_secs();
@@ -422,51 +347,23 @@ impl Queue for KeyValueStore {
                 s.list_keys(&Scope::from_segment(RunningTask::SEGMENT))?
                     .into_iter()
                     .filter_map(|k| {
-                        let task = RunningTask::try_from(k).ok()?;
-                        if task.claim_timestamp <= reschedule_timeout {
+                        let task = TaskKey::try_from(k).ok()?;
+                        if task.timestamp <= reschedule_timeout {
                             Some(task)
                         } else {
                             None
                         }
                     })
-                    .for_each(|running: RunningTask| {
-                        let pending = PendingTask {
-                            name: running.task_name.name.clone(),
-                            schedule_timestamp: now,
-                        };
+                    .for_each(|tk| {
+                        let running_key = tk.running_key();
 
-                        let _ = s.move_value(
-                            &TaskState::Running(running).into(),
-                            &TaskState::Pending(pending).into(),
-                        );
-                    });
-
-                Ok(())
-            },
-        )
-    }
-
-    fn clean_up_finished_tasks(&self, remove_after: Option<&Duration>) -> Result<()> {
-        let now = current_time();
-
-        let remove_after = remove_after.unwrap_or(&KeyValueStore::REMOVE_AFTER);
-        let remove_timeout = now - remove_after.as_secs();
-
-        self.transaction(
-            &Scope::global(),
-            &mut move |s: &dyn KeyValueStoreBackend| {
-                s.list_keys(&Scope::from_segment(FinishedTask::SEGMENT))?
-                    .into_iter()
-                    .filter_map(|k| {
-                        let task = FinishedTask::try_from(k).ok()?;
-                        if task.finish_timestamp <= remove_timeout {
-                            Some(task)
-                        } else {
-                            None
+                        let pending_key = TaskKey {
+                            name: Cow::Borrowed(&tk.name),
+                            timestamp: now,
                         }
-                    })
-                    .for_each(|finished: FinishedTask| {
-                        let _ = s.delete(&TaskState::Finished(finished).into());
+                        .pending_key();
+
+                        let _ = s.move_value(&running_key, &pending_key);
                     });
 
                 Ok(())
@@ -479,9 +376,9 @@ impl Queue for KeyValueStore {
             kv.list_keys(&Scope::from_segment(PendingTask::SEGMENT))
                 .map(|keys| {
                     keys.into_iter()
-                        .filter_map(|k| PendingTask::try_from(k).ok())
-                        .find(|p| p.name == name)
-                        .map(|p| p.schedule_timestamp)
+                        .filter_map(|k| TaskKey::try_from(k).ok())
+                        .find(|p| p.name.as_ref() == &name)
+                        .map(|p| p.timestamp)
                 })
         })
     }
@@ -492,13 +389,13 @@ mod tests {
     use std::{thread, time::Duration};
 
     use kvx_macros::segment;
-    use kvx_types::{Key, SegmentBuf};
+    use kvx_types::SegmentBuf;
     use serde_json::Value;
     use url::Url;
 
-    use super::{FinishedTask, PendingTask, Queue, RunningTask};
+    use super::{PendingTask, Queue};
     use crate::{
-        queue::{current_time, Existing, RescheduledTask},
+        queue::{now, Existing, Running},
         KeyValueStore, Namespace, ReadStore, Scope, Segment,
     };
 
@@ -523,7 +420,13 @@ mod tests {
                     let value = Value::from("value");
 
                     queue
-                        .schedule_task(segment.into(), value, None, Existing::RescheduleToNewTime)
+                        .schedule_task(
+                            segment.into(),
+                            value,
+                            None,
+                            Existing::KeepOldWithNewTime,
+                            Running::Finish,
+                        )
                         .unwrap();
                     println!("> Scheduled job {}", &name);
                 }
@@ -535,18 +438,13 @@ mod tests {
                 .unwrap();
             assert_eq!(keys.len(), 10);
 
-            for i in 1..=10 {
+            for _i in 1..=10 {
                 s.spawn(move || {
                     let queue = queue_store("test_queue");
 
                     while queue.pending_tasks_remaining().unwrap() > 0 {
-                        if let Some(task) = queue.claim_scheduled_pending_task().unwrap() {
-                            let name = Into::<Key>::into(task.state.clone());
-                            println!("- Worker {i} claimed job {name}");
-
-                            std::thread::sleep(std::time::Duration::from_millis(5));
-                            queue.finish_running_task(task, None).unwrap();
-                            println!("+ Worker {i} finished job {name}");
+                        if let Some(running_task) = queue.claim_scheduled_pending_task().unwrap() {
+                            queue.finish_running_task(running_task).unwrap();
                         }
 
                         std::thread::sleep(std::time::Duration::from_millis(5));
@@ -555,20 +453,11 @@ mod tests {
             }
         });
 
-        let pending = queue
-            .list_keys(&Scope::from_segment(PendingTask::SEGMENT))
-            .unwrap();
-        assert_eq!(pending.len(), 0);
+        let pending = queue.pending_tasks_remaining().unwrap();
+        assert_eq!(pending, 0);
 
-        let running = queue
-            .list_keys(&Scope::from_segment(RunningTask::SEGMENT))
-            .unwrap();
-        assert_eq!(running.len(), 0);
-
-        let finished = queue
-            .list_keys(&Scope::from_segment(FinishedTask::SEGMENT))
-            .unwrap();
-        assert_eq!(finished.len(), 10);
+        let running = queue.running_tasks().unwrap();
+        assert_eq!(running, 0);
     }
 
     #[test]
@@ -581,7 +470,13 @@ mod tests {
         let value = Value::from("value");
 
         queue
-            .schedule_task(segment.into(), value, None, Existing::RescheduleToNewTime)
+            .schedule_task(
+                segment.into(),
+                value,
+                None,
+                Existing::KeepOldWithNewTime,
+                Running::Finish,
+            )
             .unwrap();
 
         assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
@@ -621,28 +516,42 @@ mod tests {
 
         // Schedule the task
         queue
-            .schedule_task(segment.into(), value, None, Existing::KeepNew)
+            .schedule_task(
+                segment.into(),
+                value,
+                None,
+                Existing::KeepNew,
+                Running::Finish,
+            )
             .unwrap();
         assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
 
         // Get the task
-        let task = queue.claim_scheduled_pending_task().unwrap().unwrap();
+        let running_task = queue.claim_scheduled_pending_task().unwrap().unwrap();
         assert_eq!(queue.pending_tasks_remaining().unwrap(), 0);
+        assert_eq!(queue.running_tasks().unwrap(), 1);
 
         // Finish the task and reschedule
-        let rescheduled = RescheduledTask {
-            new_value: None,
-            schedule_timestamp: current_time(),
-        };
-        queue.finish_running_task(task, Some(rescheduled)).unwrap();
+        // queue.finish_running_task(task, Some(rescheduled)).unwrap();
+        queue
+            .schedule_task(
+                running_task.name,
+                running_task.value,
+                Some(now()),
+                Existing::KeepNew,
+                Running::Finish,
+            )
+            .unwrap();
 
-        // There should now be a new pending task
+        // There should now be a new pending task, and the
+        // running task should be removed.
         assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
+        assert_eq!(queue.running_tasks().unwrap(), 0);
 
         // Get and finish the pending task, but do not reschedule it
-        let task = queue.claim_scheduled_pending_task().unwrap().unwrap();
+        let running_task = queue.claim_scheduled_pending_task().unwrap().unwrap();
         assert_eq!(queue.pending_tasks_remaining().unwrap(), 0);
-        queue.finish_running_task(task, None).unwrap();
+        queue.finish_running_task(running_task).unwrap();
 
         // There should not be a new pending task
         assert_eq!(queue.pending_tasks_remaining().unwrap(), 0);
@@ -657,18 +566,30 @@ mod tests {
         let value_1 = Value::from("value_1");
         let value_2 = Value::from("value_2");
 
-        let in_a_while = current_time() + 180;
+        let in_a_while = now() + 180;
 
         // Schedule a task, and then schedule again replacing the old
         {
             queue
-                .schedule_task(name.clone(), value_1.clone(), None, Existing::KeepNew)
+                .schedule_task(
+                    name.clone(),
+                    value_1.clone(),
+                    None,
+                    Existing::KeepNew,
+                    Running::Finish,
+                )
                 .unwrap();
             assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
 
             // Schedule again, replacing the existing task
             queue
-                .schedule_task(name.clone(), value_2.clone(), None, Existing::KeepNew)
+                .schedule_task(
+                    name.clone(),
+                    value_2.clone(),
+                    None,
+                    Existing::KeepNew,
+                    Running::Finish,
+                )
                 .unwrap();
             assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
 
@@ -680,7 +601,13 @@ mod tests {
         // Schedule a task, and then schedule again keeping the old
         {
             queue
-                .schedule_task(name.clone(), value_1.clone(), None, Existing::KeepNew)
+                .schedule_task(
+                    name.clone(),
+                    value_1.clone(),
+                    None,
+                    Existing::KeepNew,
+                    Running::Finish,
+                )
                 .unwrap();
             queue
                 .schedule_task(
@@ -688,6 +615,7 @@ mod tests {
                     value_2.clone(),
                     Some(in_a_while),
                     Existing::KeepOld,
+                    Running::Finish,
                 )
                 .unwrap();
 
@@ -701,7 +629,13 @@ mod tests {
         // Schedule a task, and then schedule again rescheduling it
         {
             queue
-                .schedule_task(name.clone(), value_1.clone(), None, Existing::KeepNew)
+                .schedule_task(
+                    name.clone(),
+                    value_1.clone(),
+                    None,
+                    Existing::KeepNew,
+                    Running::Finish,
+                )
                 .unwrap();
 
             // we expect one pending task
@@ -713,7 +647,8 @@ mod tests {
                     name.clone(),
                     value_2.clone(),
                     Some(in_a_while),
-                    Existing::RescheduleToNewTime,
+                    Existing::KeepOldWithNewTime,
+                    Running::Finish,
                 )
                 .unwrap();
 
@@ -728,7 +663,8 @@ mod tests {
                     name.clone(),
                     value_2.clone(),
                     None,
-                    Existing::RescheduleToNewTime,
+                    Existing::KeepOldWithNewTime,
+                    Running::Finish,
                 )
                 .unwrap();
 
@@ -738,14 +674,25 @@ mod tests {
             assert_eq!(task.value, value_1);
         }
 
-        // Schedule a task, then schedule a new task keeping both.
+        // Schedule a task, then schedule a new task keeping the same time and name.
         {
-            // In case we use the same time..
             queue
-                .schedule_task(name.clone(), value_1.clone(), None, Existing::KeepNew)
+                .schedule_task(
+                    name.clone(),
+                    value_1.clone(),
+                    None,
+                    Existing::KeepNew,
+                    Running::Finish,
+                )
                 .unwrap();
             queue
-                .schedule_task(name.clone(), value_2.clone(), None, Existing::KeepBoth)
+                .schedule_task(
+                    name.clone(),
+                    value_2.clone(),
+                    None,
+                    Existing::KeepNew,
+                    Running::Finish,
+                )
                 .unwrap();
 
             // We should see only task - since name and time together are the unique key
@@ -753,26 +700,6 @@ mod tests {
             assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
             let task = queue.claim_scheduled_pending_task().unwrap().unwrap();
             assert_eq!(task.value, value_2);
-
-            // In case we use a new time, then we should have two pending tasks.
-            queue
-                .schedule_task(name.clone(), value_1.clone(), None, Existing::KeepNew)
-                .unwrap();
-            queue
-                .schedule_task(
-                    name.clone(),
-                    value_2.clone(),
-                    Some(in_a_while),
-                    Existing::KeepBoth,
-                )
-                .unwrap();
-
-            // Two pending tasks, we can get only one and its value matches old
-            assert_eq!(queue.pending_tasks_remaining().unwrap(), 2);
-            let task = queue.claim_scheduled_pending_task().unwrap().unwrap();
-            assert_eq!(task.value, value_1);
-            assert!(queue.claim_scheduled_pending_task().unwrap().is_none());
-            assert_eq!(queue.pending_tasks_remaining().unwrap(), 1);
         }
     }
 }


### PR DESCRIPTION
[draft] should merge into `prep-0.8.0` when #53 is merged.