### PR TITLE
Keep lockfiles outside of scope dirs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["kvx", "kvx-macros", "kvx-types"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/nlnetlabs/kvx"

--- a/kvx-macros/Cargo.toml
+++ b/kvx-macros/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 proc-macro = true
 
 [dependencies]
-kvx_types = { path = "../kvx-types", version = "0.9.0" }
+kvx_types = { path = "../kvx-types", version = "0.9.1" }
 proc-macro-error = "1.0.4"
 proc-macro2 = "1.0.56"
 quote = "1.0.26"

--- a/kvx/Cargo.toml
+++ b/kvx/Cargo.toml
@@ -15,8 +15,8 @@ postgres = ["dep:postgres", "dep:r2d2_postgres", "dep:postgres-types"]
 queue = []
 
 [dependencies]
-kvx_macros = { path = "../kvx-macros", version = "0.9.0", optional = true }
-kvx_types = { path = "../kvx-types", version = "0.9.0" }
+kvx_macros = { path = "../kvx-macros", version = "0.9.1", optional = true }
+kvx_types = { path = "../kvx-types", version = "0.9.1" }
 lazy_static = "1.4"
 postgres = { version = "0.19", features = [
     "with-serde_json-1",

--- a/kvx/README.md
+++ b/kvx/README.md
@@ -125,6 +125,8 @@ fn queue(store: &KeyValueStore) -> Result<(), kvx::Error> {
 
 ## Changelog
 
+### Version 0.9.1
+- Keep lock files outside of scope dirs #58
 ### Version 0.9.0
 
 Merged:

--- a/kvx/src/implementations/disk.rs
+++ b/kvx/src/implementations/disk.rs
@@ -425,7 +425,8 @@ fn list_dirs_recursive(dir: impl AsRef<Path>) -> Result<Vec<PathBuf>> {
 
     for result in fs::read_dir(dir)? {
         let path = result?.path();
-        if path.is_dir() && !path.ends_with(LOCK_FILE_DIR) {
+        if path.is_dir() && !path.ends_with(LOCK_FILE_DIR) && path.read_dir()?.next().is_some() {
+            // a non-empty directory exists for the scope, recurse and add
             dirs.extend(list_dirs_recursive(&path)?);
             dirs.push(path);
         }

--- a/kvx/src/implementations/memory.rs
+++ b/kvx/src/implementations/memory.rs
@@ -43,7 +43,7 @@ impl MemoryStore {
     }
 
     fn insert(&mut self, namespace: &NamespaceBuf, key: &Key, value: serde_json::Value) {
-        let map = self.0.entry(namespace.clone()).or_insert_with(HashMap::new);
+        let map = self.0.entry(namespace.clone()).or_default();
         map.insert(key.clone(), value);
     }
 


### PR DESCRIPTION
This is needed because otherwise, transactional reads on a non-existing scope result in creating the scope directory.